### PR TITLE
cypress account number fix

### DIFF
--- a/cypress/e2e/apply_case_spec.cy.js
+++ b/cypress/e2e/apply_case_spec.cy.js
@@ -21,9 +21,13 @@ describe('Cypress Apply Script', () => {
 		// below fails in UAT (not needed as portal thing?)
 		/// cy.get('a').contains('Apply for Legal Aid').invoke('removeAttr', 'target').click();
 		
-		//Office Check
-		///cy.get('.gov-ukradios > div:nth-child(1) > input').click();
-		cy.get('#binary-choice-form-confirm-office-true-field').click();
+		// Office Account No - different behaviour when only one choice 
+		if (cy.get('h1').contains("your office account number?")){
+			cy.get('#binary-choice-form-confirm-office-true-field').click();
+		}
+		else {
+			cy.get('.gov-ukradios > div:nth-child(1) > input').click();
+		}	
 		cy.get('#continue').click();
 		
 		//Applications


### PR DESCRIPTION
Small change to the Cypress script with aim of getting it to cope with the problem we had yesterday.
Needs to be able to cope with :

**(a)** A single account number "choice"
**(b)** Multiple account number choices.

The original version only worked with **(a)**. Now modified so it might work with both **(a)** and **(b)**. However not tested with (b) as we no longer have  multiple choices.
