### PR TITLE
cypress - fix account selection

### DIFF
--- a/cypress/e2e/apply_case_spec.cy.js
+++ b/cypress/e2e/apply_case_spec.cy.js
@@ -21,14 +21,23 @@ describe('Cypress Apply Script', () => {
 		// below fails in UAT (not needed as portal thing?)
 		/// cy.get('a').contains('Apply for Legal Aid').invoke('removeAttr', 'target').click();
 		
-		// Office Account No - different behaviour when only one choice 
-		if (cy.get('h1').contains("your office account number?")){
-			cy.get('#binary-choice-form-confirm-office-true-field').click();
-		}
-		else {
-			cy.get('.gov-ukradios > div:nth-child(1) > input').click();
-		}	
-		cy.get('#continue').click();
+		// Office Account No - different behviour for different users
+		cy.get('h1').then(($heading) => {
+			// No question to answer
+			if ($heading.text().includes('Applications')) {
+				 // do nothing
+			}
+			// Single option
+			else if ($heading.text().includes('your office account number?')) {
+				cy.get('#binary-choice-form-confirm-office-true-field').click();
+				cy.get('#continue').click();
+			}
+			// Multiple options
+			else {
+				cy.get('.gov-ukradios > div:nth-child(1) > input').click();
+				cy.get('#continue').click();
+			}
+		})
 		
 		//Applications
 		cy.get('#start').click();


### PR DESCRIPTION
Updated cypress script for `martin.ronan@example.com` user as this user doesn't get any question about supplier account number, so need to skip it.

Updated so that
- Script now skips account number selection if Applications screen found upon login (which is what martin.ronan user gets)
- Updated the conditional account number selection to not use  `cy.get('h1').contains(` as this is effectively an assert, so was not suitable for the conditional behaviour we want here.

Note script works for both `test1.example.com` and `martin.ronan@example.com` but the submissions from test1 are not successfully loaded into CCMS.    